### PR TITLE
Changed Feature Request Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,62 +1,63 @@
 name: Bug Report
 description: Let us know if something seems wrong.
 labels:
-  - bug
+    - bug
 body:
-  - type: textarea
-    id: what-happened
-    attributes:
-      label: What happened?
-      description: Please provide as much detail as possible.
-      placeholder: 'Example: The website stopped responding after I clicked a button.'
-    validations:
-      required: true
-  - type: textarea
-    id: expected-response
-    attributes:
-      label: What did you expect to happen?
-      description: Please provide as much detail as possible.
-      placeholder: 'Example: I expected the website to respond.'
-    validations:
-      required: true
-  - type: dropdown
-    id: site-page
-    attributes:
-      label: What page was this on?
-      description: Leave blank if none apply.
-      multiple: true
-      options:
-        - Main Site
-        - Blog
-        - Projects
-        - Twelve of Code
-  - type: dropdown
-    id: browsers
-    attributes:
-      label: What browser(s) were you experiencing this on?
-      description: Choose all that apply.
-      multiple: true
-      options:
-        - Google Chrome (desktop)
-        - Mozilla Firefox (desktop)
-        - Apple Safari (desktop)
-        - Microsoft Edge (desktop)
-        - Google Chrome (mobile)
-        - Apple Safari (mobile)
-        - Other (Please specify)
-  - type: textarea
-    id: logs
-    attributes:
-      label: Enter logs
-      description: This will automatically change to a codeblock.
-      render: txt
-  - type: textarea
-    id: other-notes
-    attributes:
-      label: Other notes
-      description: Enter any other relevant information here.
-  - type: markdown
-    attributes:
-      value: >-
-        [Code of Conduct](https://github.com/Mesure73L/Mesures-Website/blob/main/CODE_OF_CONDUCT.md)
-        applies.
+    - type: textarea
+      id: what-happened
+      attributes:
+          label: What happened?
+          description: Please provide as much detail as possible.
+          placeholder: "Example: The website stopped responding after I clicked a button."
+      validations:
+          required: true
+    - type: textarea
+      id: expected-response
+      attributes:
+          label: What did you expect to happen?
+          description: Please provide as much detail as possible.
+          placeholder: "Example: I expected the website to respond."
+      validations:
+          required: true
+    - type: dropdown
+      id: site-page
+      attributes:
+          label: What page was this on?
+          description: Leave blank if none apply.
+          multiple: true
+          options:
+              - Main Site
+              - Blog
+              - Projects
+              - Twelve of Code
+              - GitHub Repository
+    - type: dropdown
+      id: browsers
+      attributes:
+          label: What browser(s) were you experiencing this on?
+          description: Choose all that apply.
+          multiple: true
+          options:
+              - Google Chrome (desktop)
+              - Mozilla Firefox (desktop)
+              - Apple Safari (desktop)
+              - Microsoft Edge (desktop)
+              - Google Chrome (mobile)
+              - Apple Safari (mobile)
+              - Other (Please specify)
+    - type: textarea
+      id: logs
+      attributes:
+          label: Enter logs
+          description: This will automatically change to a codeblock.
+          render: txt
+    - type: textarea
+      id: other-notes
+      attributes:
+          label: Other notes
+          description: Enter any other relevant information here.
+    - type: markdown
+      attributes:
+          value: >-
+              [Code of Conduct](https://github.com/Mesure73L/Mesures-Website/blob/main/CODE_OF_CONDUCT.md)
+              applies.

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,53 +1,53 @@
 name: Feature Request
 description: Suggest a new feature to be added.
 labels:
-  - quality of life
-  - suggestion
+    - quality of life
+    - suggestion
 body:
-  - type: textarea
-    id: problem
-    attributes:
-      label: What problem were you having?
-      description: Only fill out if your suggestion is related to a problem.
-      placeholder: 'Example: I don''t like dark theme.'
-  - type: textarea
-    id: solution
-    attributes:
-      label: What solution would you like?
-      description: Provide as much detail as possible.
-      placeholder: 'Example: Add a switch to change to light theme.'
-    validations:
-      required: true
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: What alternatives have you considered?
-      description: Provide as much detail as possible. Do not respond with "don't do this."
-      placeholder: 'Example: Use the user''s preference for theme.'
-    validations:
-      required: true
-  - type: textarea
-    id: pros-and-cons
-    attributes:
-      label: What are some pros and cons of doing this?
-      description: Provide as much detail as possible.
-      placeholder: 'Example: Light theme is too bright for some users, but more customizability is always good'
-    validations:
-      required: true
-  - type: dropdown
-    id: site-page
-    attributes:
-      label: What page is this for?
-      description: Leave blank if none apply.
-      multiple: true
-      options:
-        - Main Site
-        - Blog
-        - Projects
-        - Twelve of Code
-        - GitHub Repository
-  - type: markdown
-    attributes:
-      value: >-
-        [Code of Conduct](https://github.com/Mesure73L/Mesures-Website/blob/main/CODE_OF_CONDUCT.md)
-        applies.
+    - type: textarea
+      id: problem
+      attributes:
+          label: What problem were you having?
+          description: Only fill out if your suggestion is related to a problem.
+          placeholder: "Example: I don't like dark theme."
+    - type: textarea
+      id: solution
+      attributes:
+          label: What solution would you like?
+          description: Provide as much detail as possible.
+          placeholder: "Example: Add a switch to change to light theme."
+      validations:
+          required: true
+    - type: textarea
+      id: alternatives
+      attributes:
+          label: What alternatives have you considered?
+          description: Provide as much detail as possible. Do not respond with "don't do this."
+          placeholder: "Example: Use the user's preference for theme."
+      validations:
+          required: true
+    - type: textarea
+      id: pros-and-cons
+      attributes:
+          label: What are some pros and cons of doing this?
+          description: Provide as much detail as possible.
+          placeholder: "Example: Light theme is too bright for some users, but more customizability is always good"
+      validations:
+          required: true
+    - type: dropdown
+      id: site-page
+      attributes:
+          label: What page is this for?
+          description: Leave blank if none apply.
+          multiple: true
+          options:
+              - Main Site
+              - Blog
+              - Projects
+              - Twelve of Code
+              - GitHub Repository
+    - type: markdown
+      attributes:
+          value: >-
+              [Code of Conduct](https://github.com/Mesure73L/Mesures-Website/blob/main/CODE_OF_CONDUCT.md)
+              applies.

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -45,6 +45,7 @@ body:
         - Blog
         - Projects
         - Twelve of Code
+        - GitHub Repository
   - type: markdown
     attributes:
       value: >-


### PR DESCRIPTION
I added "GitHub Repository" to "What page is this for?" in the feature request issue template, in case it is for something in the repository, not the website. This can be done in the bug report issue template too if desired.